### PR TITLE
Add mood-based game suggestion modal

### DIFF
--- a/src/app/giochi/page.tsx
+++ b/src/app/giochi/page.tsx
@@ -8,6 +8,7 @@ import 'aos/dist/aos.css';
 import Navbar from '../../components/Navbar';
 import GameCard from '../../components/GameCard';
 import GameModal from '../../components/GameModal';
+import SuggestGameModal from '../../components/SuggestGameModal';
 import { fetchStrapi } from '../../utils/api';
 import type { Game } from '../../types/game';
 import type { StrapiGameItem } from '../../types/strapi';
@@ -17,6 +18,7 @@ export default function GiochiPage() {
   const [categories, setCategories] = useState<string[]>([]);
   const [selectedCategory, setSelectedCategory] = useState('');
   const [selectedGame, setSelectedGame] = useState<Game | null>(null);
+  const [suggestOpen, setSuggestOpen] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -84,6 +86,26 @@ export default function GiochiPage() {
   };
   const closeModal = () => setSelectedGame(null);
 
+  const handleRandom = () => {
+    if (games.length === 0) return;
+    const randomGame = games[Math.floor(Math.random() * games.length)];
+    setSelectedGame(randomGame);
+    setSuggestOpen(false);
+  };
+
+  const handleSuggest = (category: string) => {
+    const moodGames = games.filter((g) =>
+      g.categoria
+        .split(/\s+/)
+        .map((c) => c.trim())
+        .includes(category),
+    );
+    if (moodGames.length === 0) return;
+    const randomGame = moodGames[Math.floor(Math.random() * moodGames.length)];
+    setSelectedGame(randomGame);
+    setSuggestOpen(false);
+  };
+
   return (
     <>
       <Navbar />
@@ -125,7 +147,13 @@ export default function GiochiPage() {
               <p className="text-center text-red-500">{error}</p>
             ) : (
               <>
-                <div className="mb-6" data-aos="fade-up" data-aos-delay={350}>
+                <div className="mb-6 space-y-4" data-aos="fade-up" data-aos-delay={350}>
+                  <button
+                    onClick={() => setSuggestOpen(true)}
+                    className="w-full bg-brand-yellow text-gray-900 font-bold py-2 rounded-lg shadow hover:bg-brand-yellow/90 transition-colors"
+                  >
+                    Non sai a cosa giocare? CLICCAMI!
+                  </button>
                   <label htmlFor="categorySelect" className="sr-only">
                     Filtra per categoria
                   </label>
@@ -166,6 +194,14 @@ export default function GiochiPage() {
 
       {selectedGame && (
         <GameModal game={selectedGame} onClose={closeModal} />
+      )}
+      {suggestOpen && (
+        <SuggestGameModal
+          categories={categories}
+          onRandom={handleRandom}
+          onSuggest={handleSuggest}
+          onClose={() => setSuggestOpen(false)}
+        />
       )}
     </>
   );

--- a/src/components/GameCard.tsx
+++ b/src/components/GameCard.tsx
@@ -65,15 +65,30 @@ const GameCard: React.FC<GameCardProps> = ({ game, onClick, gradientIndex }) => 
             </p>
           </div>
           <div className="flex justify-between items-center mt-2">
-            <span className={`text-xs ${selectedGradient.dateColor} opacity-90`}>
-              {game.categoria}
-            </span>
+            <div className="flex flex-wrap gap-1">
+              {game.categoria
+                .split(/\s+/)
+                .map((c) => c.trim())
+                .filter(Boolean)
+                .map((cat) => (
+                  <span
+                    key={cat}
+                    className={`px-2 py-0.5 rounded-full text-xs font-medium ${selectedGradient.dateColor} ${
+                      selectedGradient.buttonText === 'text-gray-800'
+                        ? 'bg-black/20'
+                        : 'bg-white/20'
+                    }`}
+                  >
+                    {cat}
+                  </span>
+                ))}
+            </div>
             <button
               className={`
                 px-4 py-1.5
-                border ${selectedGradient.buttonBorder} rounded-lg 
+                border ${selectedGradient.buttonBorder} rounded-lg
                 text-xs font-semibold ${selectedGradient.buttonText}
-                hover:bg-white/10 dark:hover:bg-black/10 
+                hover:bg-white/10 dark:hover:bg-black/10
                 transition-colors duration-200
               `}
             >

--- a/src/components/SuggestGameModal.tsx
+++ b/src/components/SuggestGameModal.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+
+interface SuggestGameModalProps {
+  categories: string[];
+  onRandom: () => void;
+  onSuggest: (category: string) => void;
+  onClose: () => void;
+}
+
+const IconClose = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+    <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+  </svg>
+);
+
+export default function SuggestGameModal({ categories, onRandom, onSuggest, onClose }: SuggestGameModalProps) {
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const [mood, setMood] = useState('');
+
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    const onKey = (e: KeyboardEvent) => e.key === 'Escape' && onClose();
+    window.addEventListener('keydown', onKey);
+    return () => {
+      document.body.style.overflow = '';
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [onClose]);
+
+  const handleOverlay = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === overlayRef.current) onClose();
+  };
+
+  return (
+    <div
+      ref={overlayRef}
+      onClick={handleOverlay}
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 backdrop-blur-sm p-4 sm:p-6 lg:p-8 transition-opacity duration-300 ease-in-out animate-fadeIn"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="suggest-game-title"
+    >
+      <div className="bg-gray-800 text-gray-100 rounded-2xl shadow-2xl w-full max-w-md p-6 space-y-4 animate-modalContentShow">
+        <div className="flex justify-between items-start">
+          <h2 id="suggest-game-title" className="text-xl font-bold">Consiglio Gioco</h2>
+          <button onClick={onClose} aria-label="Chiudi" className="text-gray-400 hover:text-white transition-colors">
+            <IconClose />
+          </button>
+        </div>
+        <button
+          onClick={onRandom}
+          className="w-full bg-brand-yellow text-gray-900 font-semibold px-4 py-2 rounded-lg hover:bg-brand-yellow/90 transition-colors"
+        >
+          Gioco casuale
+        </button>
+        <div>
+          <label htmlFor="moodSelect" className="block text-sm font-medium text-gray-300 mb-1">
+            Scegli un mood
+          </label>
+          <select
+            id="moodSelect"
+            value={mood}
+            onChange={(e) => setMood(e.target.value)}
+            className="w-full bg-gray-700 text-gray-100 rounded-md px-3 py-2 mb-3 focus:outline-none focus:ring-2 focus:ring-brand-blue"
+          >
+            <option value="">Seleziona...</option>
+            {categories.map((cat) => (
+              <option key={cat} value={cat}>
+                {cat}
+              </option>
+            ))}
+          </select>
+          <button
+            onClick={() => mood && onSuggest(mood)}
+            disabled={!mood}
+            className="w-full bg-brand-blue text-white font-semibold px-4 py-2 rounded-lg hover:bg-brand-blue/90 transition-colors disabled:opacity-50"
+          >
+            Suggerisci
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- implement `SuggestGameModal` with random and mood based suggestions
- add button on games page to open the new modal
- wire modal actions to open `GameModal` with a selected game

## Testing
- `npm run lint`
