### PR TITLE
Add player count filter for games

### DIFF
--- a/src/app/giochi/page.tsx
+++ b/src/app/giochi/page.tsx
@@ -16,6 +16,8 @@ export default function GiochiPage() {
   const [games, setGames] = useState<Game[]>([]);
   const [categories, setCategories] = useState<string[]>([]);
   const [selectedCategory, setSelectedCategory] = useState('');
+  const [playersBounds, setPlayersBounds] = useState<[number, number]>([0, 0]);
+  const [selectedPlayers, setSelectedPlayers] = useState<[number, number]>([0, 0]);
   const [selectedGame, setSelectedGame] = useState<Game | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -45,6 +47,19 @@ export default function GiochiPage() {
             : '/img/placeholder.jpg',
         }));
         setGames(parsedGames);
+
+        // Calcola intervallo minimo e massimo di giocatori
+        const playersNumbers = parsedGames
+          .map((g) => g.giocatori.split('-').map((n) => parseInt(n, 10)))
+          .filter((arr) => arr.length === 2 && !arr.some((n) => isNaN(n)));
+        const minPlayers = playersNumbers.length
+          ? Math.min(...playersNumbers.map((p) => p[0]))
+          : 0;
+        const maxPlayers = playersNumbers.length
+          ? Math.max(...playersNumbers.map((p) => p[1]))
+          : 0;
+        setPlayersBounds([minPlayers, maxPlayers]);
+        setSelectedPlayers([minPlayers, maxPlayers]);
         const uniqueCategories = Array.from(
 
           new Set(
@@ -67,16 +82,20 @@ export default function GiochiPage() {
     fetchGiochi();
   }, []);
 
-  const filteredGames = selectedCategory
-
+  const gamesByCategory = selectedCategory
     ? games.filter((g) =>
         g.categoria
           .split(/\s+/)
           .map((c) => c.trim())
           .includes(selectedCategory),
       )
-
     : games;
+
+  const filteredGames = gamesByCategory.filter((g) => {
+    const [minP, maxP] = g.giocatori.split('-').map((n) => parseInt(n, 10));
+    if (isNaN(minP) || isNaN(maxP)) return true;
+    return maxP >= selectedPlayers[0] && minP <= selectedPlayers[1];
+  });
 
   const openModal = (id: string) => {
     const game = games.find((g) => g.id === id) ?? null;
@@ -142,6 +161,39 @@ export default function GiochiPage() {
                       </option>
                     ))}
                   </select>
+                </div>
+                <div className="mb-6" data-aos="fade-up" data-aos-delay={360}>
+                  <label className="block text-sm mb-2" htmlFor="players-range">
+                    Giocatori: {selectedPlayers[0]} - {selectedPlayers[1]}
+                  </label>
+                  <div className="flex items-center space-x-2" id="players-range">
+                    <input
+                      type="range"
+                      min={playersBounds[0]}
+                      max={playersBounds[1]}
+                      value={selectedPlayers[0]}
+                      onChange={(e) =>
+                        setSelectedPlayers([
+                          Math.min(Number(e.target.value), selectedPlayers[1]),
+                          selectedPlayers[1],
+                        ])
+                      }
+                      className="flex-1 accent-brand-yellow h-2"
+                    />
+                    <input
+                      type="range"
+                      min={playersBounds[0]}
+                      max={playersBounds[1]}
+                      value={selectedPlayers[1]}
+                      onChange={(e) =>
+                        setSelectedPlayers([
+                          selectedPlayers[0],
+                          Math.max(Number(e.target.value), selectedPlayers[0]),
+                        ])
+                      }
+                      className="flex-1 accent-brand-yellow h-2"
+                    />
+                  </div>
                 </div>
                 <div
                   id="lista-giochi-container"

--- a/src/components/GameCard.tsx
+++ b/src/components/GameCard.tsx
@@ -65,15 +65,30 @@ const GameCard: React.FC<GameCardProps> = ({ game, onClick, gradientIndex }) => 
             </p>
           </div>
           <div className="flex justify-between items-center mt-2">
-            <span className={`text-xs ${selectedGradient.dateColor} opacity-90`}>
-              {game.categoria}
-            </span>
+            <div className="flex flex-wrap gap-1">
+              {game.categoria
+                .split(/\s+/)
+                .map((c) => c.trim())
+                .filter(Boolean)
+                .map((cat) => (
+                  <span
+                    key={cat}
+                    className={`px-2 py-0.5 rounded-full text-xs font-medium ${selectedGradient.dateColor} ${
+                      selectedGradient.buttonText === 'text-gray-800'
+                        ? 'bg-black/20'
+                        : 'bg-white/20'
+                    }`}
+                  >
+                    {cat}
+                  </span>
+                ))}
+            </div>
             <button
               className={`
                 px-4 py-1.5
-                border ${selectedGradient.buttonBorder} rounded-lg 
+                border ${selectedGradient.buttonBorder} rounded-lg
                 text-xs font-semibold ${selectedGradient.buttonText}
-                hover:bg-white/10 dark:hover:bg-black/10 
+                hover:bg-white/10 dark:hover:bg-black/10
                 transition-colors duration-200
               `}
             >


### PR DESCRIPTION
## Summary
- add range slider state and player parsing
- compute bounds of player counts from games list
- filter games by selected player range
- render dual-range slider UI above the game grid

## Testing
- `npm run lint`
