### PR TITLE
Improve player filter slider

### DIFF
--- a/src/app/giochi/page.tsx
+++ b/src/app/giochi/page.tsx
@@ -19,6 +19,8 @@ export default function GiochiPage() {
   const [selectedGame, setSelectedGame] = useState<Game | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [playerBounds, setPlayerBounds] = useState({ min: 0, max: 0 });
+  const [selectedPlayers, setSelectedPlayers] = useState<number | null>(null);
 
   useEffect(() => {
     AOS.init({ duration: 600, once: true, offset: 50 });
@@ -45,6 +47,16 @@ export default function GiochiPage() {
             : '/img/placeholder.jpg',
         }));
         setGames(parsedGames);
+        const minPlayersArr = parsedGames
+          .map((g) => parseInt(g.giocatori.split('-')[0], 10))
+          .filter((n) => !isNaN(n));
+        const maxPlayersArr = parsedGames
+          .map((g) => parseInt(g.giocatori.split('-')[1], 10))
+          .filter((n) => !isNaN(n));
+        const globalMin = Math.min(...minPlayersArr);
+        const globalMax = Math.max(...maxPlayersArr);
+        setPlayerBounds({ min: globalMin, max: globalMax });
+        setSelectedPlayers(null);
         const uniqueCategories = Array.from(
 
           new Set(
@@ -67,16 +79,21 @@ export default function GiochiPage() {
     fetchGiochi();
   }, []);
 
-  const filteredGames = selectedCategory
-
-    ? games.filter((g) =>
-        g.categoria
-          .split(/\s+/)
-          .map((c) => c.trim())
-          .includes(selectedCategory),
-      )
-
-    : games;
+  const filteredGames = games
+    .filter((g) => {
+      if (!selectedCategory) return true;
+      return g.categoria
+        .split(/\s+/)
+        .map((c) => c.trim())
+        .includes(selectedCategory);
+    })
+    .filter((g) => {
+      if (selectedPlayers === null) return true;
+      const parts = g.giocatori.split('-').map((n) => parseInt(n, 10));
+      const [minP, maxP] = parts.length === 2 ? parts : [parts[0], parts[0]];
+      if (isNaN(minP) || isNaN(maxP)) return true;
+      return selectedPlayers >= minP && selectedPlayers <= maxP;
+    });
 
   const openModal = (id: string) => {
     const game = games.find((g) => g.id === id) ?? null;
@@ -125,23 +142,38 @@ export default function GiochiPage() {
               <p className="text-center text-red-500">{error}</p>
             ) : (
               <>
-                <div className="mb-6" data-aos="fade-up" data-aos-delay={350}>
-                  <label htmlFor="categorySelect" className="sr-only">
-                    Filtra per categoria
-                  </label>
-                  <select
-                    id="categorySelect"
-                    value={selectedCategory}
-                    onChange={(e) => setSelectedCategory(e.target.value)}
-                    className="bg-gray-700 text-gray-100 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-blue"
-                  >
-                    <option value="">Tutte le categorie</option>
-                    {categories.map((cat) => (
-                      <option key={cat} value={cat}>
-                        {cat}
-                      </option>
-                    ))}
-                  </select>
+                <div className="flex flex-wrap items-center gap-4 mb-6" data-aos="fade-up" data-aos-delay={350}>
+                  <div>
+                    <label htmlFor="categorySelect" className="sr-only">Filtra per categoria</label>
+                    <select
+                      id="categorySelect"
+                      value={selectedCategory}
+                      onChange={(e) => setSelectedCategory(e.target.value)}
+                      className="bg-gray-700 text-gray-100 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-blue"
+                    >
+                      <option value="">Tutte le categorie</option>
+                      {categories.map((cat) => (
+                        <option key={cat} value={cat}>
+                          {cat}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div className="flex items-center gap-2 flex-1 sm:flex-none">
+                    <label htmlFor="playerSlider" className="sr-only">Filtra per giocatori</label>
+                    <input
+                      id="playerSlider"
+                      type="range"
+                      min={playerBounds.min}
+                      max={playerBounds.max}
+                      value={selectedPlayers ?? playerBounds.min}
+                      onChange={(e) => setSelectedPlayers(parseInt(e.target.value))}
+                      className="range-input flex-1"
+                    />
+                    <span className="text-sm w-12 text-center">
+                      {selectedPlayers ?? 'Tutti'}
+                    </span>
+                  </div>
                 </div>
                 <div
                   id="lista-giochi-container"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -169,3 +169,28 @@ body {
 .modal-game-description {
   @apply mt-4 text-gray-400 text-sm sm:text-base leading-relaxed flex-grow;
 }
+
+/* Slider style */
+.range-input {
+  -webkit-appearance: none;
+  width: 100%;
+  height: 0.5rem;
+  border-radius: 9999px;
+  background-color: #4b5563; /* gray-700 */
+  cursor: pointer;
+}
+.range-input::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  height: 1rem;
+  width: 1rem;
+  border-radius: 9999px;
+  background-color: #f59e0b; /* brand-yellow */
+  border: none;
+}
+.range-input::-moz-range-thumb {
+  height: 1rem;
+  width: 1rem;
+  border-radius: 9999px;
+  background-color: #f59e0b;
+  border: none;
+}

--- a/src/components/GameCard.tsx
+++ b/src/components/GameCard.tsx
@@ -65,15 +65,30 @@ const GameCard: React.FC<GameCardProps> = ({ game, onClick, gradientIndex }) => 
             </p>
           </div>
           <div className="flex justify-between items-center mt-2">
-            <span className={`text-xs ${selectedGradient.dateColor} opacity-90`}>
-              {game.categoria}
-            </span>
+            <div className="flex flex-wrap gap-1">
+              {game.categoria
+                .split(/\s+/)
+                .map((c) => c.trim())
+                .filter(Boolean)
+                .map((cat) => (
+                  <span
+                    key={cat}
+                    className={`px-2 py-0.5 rounded-full text-xs font-medium ${selectedGradient.dateColor} ${
+                      selectedGradient.buttonText === 'text-gray-800'
+                        ? 'bg-black/20'
+                        : 'bg-white/20'
+                    }`}
+                  >
+                    {cat}
+                  </span>
+                ))}
+            </div>
             <button
               className={`
                 px-4 py-1.5
-                border ${selectedGradient.buttonBorder} rounded-lg 
+                border ${selectedGradient.buttonBorder} rounded-lg
                 text-xs font-semibold ${selectedGradient.buttonText}
-                hover:bg-white/10 dark:hover:bg-black/10 
+                hover:bg-white/10 dark:hover:bg-black/10
                 transition-colors duration-200
               `}
             >


### PR DESCRIPTION
## Summary
- compute player range bounds on the games page
- allow filtering games by players using a styled range slider
- show the slider next to the category dropdown
- add custom styles for the range input

## Testing
- `npm run lint`